### PR TITLE
Move snaps to top of events table

### DIFF
--- a/circlevis/replay_info.py
+++ b/circlevis/replay_info.py
@@ -103,8 +103,8 @@ class ReplayInfo(QFrame):
                     if judgment.within(self.EDGE_HIT_THRESH):
                         edge_hits.append(EdgeHitEvent(judgment))
 
-        events.extend(misses)
         events.extend(snap_events)
+        events.extend(misses)
         events.extend(edge_hits)
         events.extend(hit100s)
         events.extend(hit50s)

--- a/circlevis/replay_info.py
+++ b/circlevis/replay_info.py
@@ -104,8 +104,8 @@ class ReplayInfo(QFrame):
                         edge_hits.append(EdgeHitEvent(judgment))
 
         events.extend(snap_events)
-        events.extend(misses)
         events.extend(edge_hits)
+        events.extend(misses)
         events.extend(hit100s)
         events.extend(hit50s)
 


### PR DESCRIPTION
Fixes https://github.com/circleguard/circleguard/issues/163 by adding `snap_events` to `events` list first.

Should `edge_hits` be above misses too for consistency?