### PR TITLE
Limit amount of replays' statistics preloaded to 5

### DIFF
--- a/circlevis/interface.py
+++ b/circlevis/interface.py
@@ -33,9 +33,13 @@ class Interface(QWidget):
         for replay in replays:
             self.replay_statistics_precalculated[replay] = (None, None, None, None)
 
-        # if 5 or less replays are loaded, preload replay statistics
-        # otherwise visualiser will heavily slow down and lag until all replay
-        # data is loaded.
+        # only precalculate statistics if we're visualizing 5 or fewer replays.
+        # Otherwise, the thread is too overworked and lags the main draw thread
+        # significantly until all statistics are precalculated.
+        # TODO This may be resolved properly by using a QThread with a low
+        # priority instead, so as not to starve the draw thread. We should be
+        # using QThreads instead of python threads regardless.
+
         if len(replays) <= 5:
             # and here's the thread which will actually start those calculations
             cg_statistics_worked = Thread(target=self.calculate_cg_statistics)

--- a/circlevis/interface.py
+++ b/circlevis/interface.py
@@ -33,11 +33,15 @@ class Interface(QWidget):
         for replay in replays:
             self.replay_statistics_precalculated[replay] = (None, None, None, None)
 
-        # and here's the thread which will actually start those calculations
-        cg_statistics_worked = Thread(target=self.calculate_cg_statistics)
-        # allow users to quit before we're done calculating
-        cg_statistics_worked.daemon = True
-        cg_statistics_worked.start()
+        # if 5 or less replays are loaded, preload replay statistics
+        # otherwise visualiser will heavily slow down and lag until all replay
+        # data is loaded.
+        if len(replays) <= 5:
+            # and here's the thread which will actually start those calculations
+            cg_statistics_worked = Thread(target=self.calculate_cg_statistics)
+            # allow users to quit before we're done calculating
+            cg_statistics_worked.daemon = True
+            cg_statistics_worked.start()
 
         # create our own library in a temp dir if one wasn't passed
         if not self.library:


### PR DESCRIPTION
Fixes https://github.com/circleguard/circleguard/issues/162 by limiting amount of preloaded replay stats to an arbitrary amount (5).

For me, loading the replay data on demand is fast enough that I don't see any slowdown when I click on a user's replay info. (This will depend on the user's machine though).

This will probably do until we implement something more robust and works better with Qt, like `QThread`, mentioned [here](https://discord.com/channels/532476765860265984/532477317382144001/863878716434284594).