### PR TITLE
Allow `CheckboxSetting`s to be toggled on label/frame click

### DIFF
--- a/circlevis/widgets.py
+++ b/circlevis/widgets.py
@@ -45,6 +45,7 @@ class CheckboxSetting(QFrame):
         layout.addWidget(label, 3)
         layout.addWidget(self.checkbox, 1)
         layout.setContentsMargins(0, 3, 0, 3)
+        self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         self.setLayout(layout)
 
     def checked(self):
@@ -52,6 +53,11 @@ class CheckboxSetting(QFrame):
 
     def _state_changed(self, state):
         self.state_changed.emit(state == Qt.CheckState.Checked.value)
+
+    # toggle checkbox if we're clicked anywhere in this frame,
+    # so the label can be clicked to toggle as well
+    def mousePressEvent(self, event):
+        self.checkbox.toggle()
 
 
 class SliderSetting(QFrame):

--- a/circlevis/widgets.py
+++ b/circlevis/widgets.py
@@ -54,9 +54,9 @@ class CheckboxSetting(QFrame):
     def _state_changed(self, state):
         self.state_changed.emit(state == Qt.CheckState.Checked.value)
 
-    # toggle checkbox if we're clicked anywhere in this frame,
-    # so the label can be clicked to toggle as well
-    def mousePressEvent(self, event):
+    # toggle checkbox if we're clicked anywhere, so the label can be clicked to
+    # toggle as well
+    def mousePressEvent(self, _event):
         self.checkbox.toggle()
 
 


### PR DESCRIPTION
As mentioned in https://github.com/circleguard/circlevis/pull/18#issuecomment-1696577473 the checkboxes for settings are a little small and allowing for clicking on the label/containing frame is definitely beneficial.

Mainly taken from https://github.com/circleguard/circleguard/blob/87066fda7ccbba3e83040fa46a090b6af9bc874a/circleguard/widgets.py#L381

Unsure if we want the comment in there, feel free to modify if you want :)